### PR TITLE
Fix: Parser of the manga id

### DIFF
--- a/manga_livre_dl/manga_livre_dl.py
+++ b/manga_livre_dl/manga_livre_dl.py
@@ -27,7 +27,7 @@ class MangaLivreDl:
     
 
     def get_manga_chapters(self, url, chapter_selection):
-        manga_id = url.split('/')[-1]
+        manga_id = url.split('/')[-2]
         manga_chapters = []
         offset = 0
         while True:


### PR DESCRIPTION
The manga ID is not the last item anymore so i changed the parser to match the new pattern of url

New website url pattern: https://mangalivre.net/manga/7739/chainsaw-man

